### PR TITLE
fix(markup): limit height for tall images

### DIFF
--- a/TRMNL_Comic.md
+++ b/TRMNL_Comic.md
@@ -29,7 +29,7 @@ Copy and paste the following code into the Markup box. This code will display a 
       <div class="column">
         <div class="content content">
           <!-- Centered Comic Image -->
-          <img src="{{ img }}" alt="{{ title }}" style="display: block; margin: 0 auto; max-width: 80%; height: auto; border-radius: 5px;" />
+          <img src="{{ img }}" alt="{{ title }}" style="display: block; margin: 0 auto; max-width: 90vw; max-height: 87vh; border-radius: 5px;">
         </div>
       </div>
     </div>


### PR DESCRIPTION
If the image is a tall image it might cutoff the bottom of the strip

**Before**

Code with hardcoded image that is a tall comic to see the bug
```
<img src="https://imgs.xkcd.com/comics/archive_request.png" alt="Archive Request" style="display: block; margin: 0 auto; max-width: 80%; height: auto; border-radius: 5px;" />
```
Image
<img width="794" alt="image" src="https://github.com/user-attachments/assets/407fb6e1-7367-406e-bbb7-d19164c80b92" />


**Now**

Code with hardcoded image that is a tall comic to see the fix
```
<img src="https://imgs.xkcd.com/comics/archive_request.png" alt="Archive Request" style="display: block; margin: 0 auto; max-width: 90vw; max-height: 87vh; border-radius: 5px;">
```

Image
<img width="795" alt="image" src="https://github.com/user-attachments/assets/41b9b3d9-17f0-4128-8611-5351c4aa81ff" />




Another example:
<img width="804" alt="image" src="https://github.com/user-attachments/assets/cc8cbe1f-5825-40c6-9bfb-ca04358ceb04" /> 
<img width="807" alt="image" src="https://github.com/user-attachments/assets/82df60ee-9c34-471b-beef-0e40ab67f277" />
